### PR TITLE
feat: add `EasySocket` trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -495,9 +495,9 @@ dependencies = [
 
 [[package]]
 name = "psp"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34802bbcf46f255ee06e864bf4497bb264f308113b000facd08a32dd154936e0"
+checksum = "b5da5105eb984565819ac0f3e09132991b9169b1b57f7172573eb710507a276b"
 dependencies = [
  "bitflags",
  "libm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ default = []
 std = []
 
 [dependencies]
-psp = { version = "0.3.8" }
+psp = { version = "0.3.9" }
 dns-protocol = { version = "0.1.1", default-features = false }
 embedded-tls = { version = "0.17", default-features = false }
 embedded-io = { version = "0.6.1", default-features = false }

--- a/src/dns.rs
+++ b/src/dns.rs
@@ -47,7 +47,7 @@ impl DnsResolver {
     /// Create a new DNS resolver
     #[allow(unused)]
     pub fn new(dns: SocketAddr) -> Result<Self, DnsError> {
-        let mut udp_socket = UdpSocket::open().map_err(|_| DnsError::FailedToCreate)?;
+        let mut udp_socket = UdpSocket::new().map_err(|_| DnsError::FailedToCreate)?;
         udp_socket
             .bind(Some(dns))
             .map_err(|_| DnsError::FailedToCreate)?;
@@ -59,7 +59,7 @@ impl DnsResolver {
     /// The default settings are to use Google's DNS server at `8.8.8.8:53`
     pub fn try_default() -> Result<Self, DnsError> {
         let dns = *GOOGLE_DNS_HOST;
-        let mut udp_socket = UdpSocket::open().map_err(|_| DnsError::FailedToCreate)?;
+        let mut udp_socket = UdpSocket::new().map_err(|_| DnsError::FailedToCreate)?;
         udp_socket
             .bind(None)
             .map_err(|_| DnsError::FailedToCreate)?;

--- a/src/dns.rs
+++ b/src/dns.rs
@@ -20,8 +20,8 @@ lazy_static::lazy_static! {
     static ref GOOGLE_DNS_HOST: SocketAddr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)), DNS_PORT);
 }
 
-#[allow(unused)]
 /// Create a DNS query for an A record
+#[allow(unused)]
 pub fn create_a_type_query(domain: &str) -> Question {
     Question::new(domain, dns_protocol::ResourceType::A, 1)
 }

--- a/src/dns.rs
+++ b/src/dns.rs
@@ -77,7 +77,7 @@ impl DnsResolver {
     /// - `Err(())`: If the hostname could not be resolved
     pub fn resolve(&mut self, host: &str) -> Result<in_addr, DnsError> {
         // connect to the DNS server, if not already
-        if self.udp_socket.get_socket_state() != UdpSocketState::Connected {
+        if self.udp_socket.get_state() != UdpSocketState::Connected {
             self.udp_socket
                 .connect(self.dns)
                 .map_err(|e| DnsError::HostnameResolutionFailed(e.to_string()))?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 #![cfg_attr(not(feature = "std"), no_std)]
+#![feature(trait_alias)]
 
 extern crate alloc;
 
@@ -7,8 +8,13 @@ pub mod dns;
 pub mod netc;
 pub mod socket;
 pub mod traits;
+pub mod types;
 pub mod utils;
 
 // re-export
 pub type SocketAddr = embedded_nal::SocketAddr;
 pub type TlsError = embedded_tls::TlsError;
+
+pub trait Write = embedded_io::Write;
+pub trait Read = embedded_io::Read;
+pub trait ErrorType = embedded_io::ErrorType;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@ pub mod traits;
 pub mod types;
 pub mod utils;
 
-// re-export
+// re-exports
 pub type SocketAddr = embedded_nal::SocketAddr;
 pub type TlsError = embedded_tls::TlsError;
 

--- a/src/netc.rs
+++ b/src/netc.rs
@@ -9,9 +9,9 @@ pub use psp::sys::in_addr;
 
 pub use psp::sys::sockaddr;
 
+/// A structure like Linux's `sockaddr_in`
 #[repr(C)]
 #[allow(nonstandard_style)]
-// TODO: document
 pub struct sockaddr_in {
     pub sin_len: u8,
     pub sin_family: u8,

--- a/src/socket/tcp.rs
+++ b/src/socket/tcp.rs
@@ -1,6 +1,6 @@
 use alloc::boxed::Box;
 use alloc::vec::Vec;
-use embedded_io::ErrorType;
+use embedded_io::{ErrorType, Read, Write};
 
 use embedded_nal::SocketAddr;
 use psp::sys;
@@ -16,13 +16,12 @@ use super::super::netc;
 use super::error::SocketError;
 use super::ToSockaddr;
 
-#[repr(C)]
 /// A TCP socket
 ///
 /// # Fields
-/// - [`Self::fd`]: The socket file descriptor
-/// - [`Self::is_connected`]: Whether the socket is connected
-/// - [`Self::buffer`]: The buffer to store data to send
+/// - [`fd`](Self::fd): The socket file descriptor
+/// - [`is_connected`](Self::is_connected): Whether the socket is connected
+/// - [`buffer`](Self::buffer): The buffer to store data to send
 ///
 /// # Safety
 /// This is a wrapper around a raw socket file descriptor.
@@ -45,6 +44,7 @@ use super::ToSockaddr;
 /// socket.flush().unwrap();
 /// // no need to call close, as drop will do it
 /// ```
+#[repr(C)]
 pub struct TcpSocket {
     fd: i32,
     is_connected: bool,
@@ -186,7 +186,7 @@ impl Open for TcpSocket {
     }
 }
 
-impl embedded_io::Read for TcpSocket {
+impl Read for TcpSocket {
     /// Read from the socket
     fn read<'m>(&'m mut self, buf: &'m mut [u8]) -> Result<usize, Self::Error> {
         if !self.is_connected {
@@ -196,7 +196,7 @@ impl embedded_io::Read for TcpSocket {
     }
 }
 
-impl embedded_io::Write for TcpSocket {
+impl Write for TcpSocket {
     /// Write to the socket
     fn write<'m>(&'m mut self, buf: &'m [u8]) -> Result<usize, Self::Error> {
         if !self.is_connected {

--- a/src/socket/tls.rs
+++ b/src/socket/tls.rs
@@ -1,5 +1,5 @@
 use alloc::string::String;
-use embedded_io::Write;
+use embedded_io::{ErrorType, Read, Write};
 use embedded_tls::{
     blocking::TlsConnection, Aes128GcmSha256, Certificate, NoVerify, TlsConfig, TlsContext,
 };
@@ -7,6 +7,11 @@ use embedded_tls::{
 use rand::SeedableRng;
 use rand_chacha::ChaCha20Rng;
 use regex::Regex;
+
+use crate::{
+    traits::io::{Open, OptionType},
+    types::TlsSocketOptions,
+};
 
 use super::tcp::TcpSocket;
 
@@ -83,27 +88,9 @@ impl<'a> TlsSocket<'a> {
         [0; 16_384]
     }
 
-    /// Open the TLS connection.
-    pub fn open(&mut self, seed: u64) -> Result<(), embedded_tls::TlsError> {
-        let mut rng = ChaCha20Rng::seed_from_u64(seed);
-        let tls_context = TlsContext::new(&self.tls_config, &mut rng);
-        self.tls_connection
-            .open::<ChaCha20Rng, NoVerify>(tls_context)
-    }
-
-    /// Write data to the TLS connection.
-    pub fn write(&mut self, buf: &[u8]) -> Result<usize, embedded_tls::TlsError> {
-        self.tls_connection.write(buf)
-    }
-
     /// Write all data to the TLS connection.
     pub fn write_all(&mut self, buf: &[u8]) -> Result<(), embedded_tls::TlsError> {
         self.tls_connection.write_all(buf)
-    }
-
-    /// Read data from the TLS connection.
-    pub fn read(&mut self, buf: &mut [u8]) -> Result<usize, embedded_tls::TlsError> {
-        self.tls_connection.read(buf)
     }
 
     /// Read data from the TLS connection and converts it to a [`String`].
@@ -115,9 +102,41 @@ impl<'a> TlsSocket<'a> {
         let text = REGEX.replace_all(&text, "");
         Ok(text.into_owned())
     }
+}
+
+impl ErrorType for TlsSocket<'_> {
+    type Error = embedded_tls::TlsError;
+}
+
+impl OptionType for TlsSocket<'_> {
+    type Options = TlsSocketOptions;
+}
+
+impl Open for TlsSocket<'_> {
+    /// Open the TLS connection.
+    fn open(&mut self, options: Self::Options) -> Result<(), embedded_tls::TlsError> {
+        let mut rng = ChaCha20Rng::seed_from_u64(options.seed());
+        let tls_context = TlsContext::new(&self.tls_config, &mut rng);
+        self.tls_connection
+            .open::<ChaCha20Rng, NoVerify>(tls_context)
+    }
+}
+
+impl embedded_io::Read for TlsSocket<'_> {
+    /// Read data from the TLS connection.
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
+        self.tls_connection.read(buf)
+    }
+}
+
+impl embedded_io::Write for TlsSocket<'_> {
+    /// Write data to the TLS connection.
+    fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
+        self.tls_connection.write(buf)
+    }
 
     /// Flush the TLS connection.
-    pub fn flush(&mut self) -> Result<(), embedded_tls::TlsError> {
+    fn flush(&mut self) -> Result<(), Self::Error> {
         self.tls_connection.flush()
     }
 }

--- a/src/socket/udp.rs
+++ b/src/socket/udp.rs
@@ -282,12 +282,11 @@ impl embedded_io::ErrorType for UdpSocket {
 }
 
 impl Open for UdpSocket {
-    fn open(options: Self::Options) -> Result<Self, Self::Error> {
-        let mut socket = Self::new()?;
-        socket.bind(None)?;
-        socket.connect(options.remote())?;
+    fn open(&mut self, options: Self::Options) -> Result<(), Self::Error> {
+        self.bind(None)?;
+        self.connect(options.remote())?;
 
-        Ok(socket)
+        Ok(())
     }
 }
 

--- a/src/socket/udp.rs
+++ b/src/socket/udp.rs
@@ -25,7 +25,6 @@ pub enum UdpSocketState {
     Connected,
 }
 
-#[repr(C)]
 /// A UDP socket
 ///
 /// # Fields
@@ -41,6 +40,7 @@ pub enum UdpSocketState {
 ///   providing the [`open`](Self::open) method as an alternative to [`new`](Self::new).
 ///   This method return a [`UdpSocket`] already connected, and ready to send/receive data (using the
 ///   [`write`](embedded_io::Write::write) and [`read`](embedded_io::Read::read) methods).
+#[repr(C)]
 pub struct UdpSocket {
     fd: i32,
     remote: Option<sockaddr>,

--- a/src/socket/udp.rs
+++ b/src/socket/udp.rs
@@ -23,29 +23,34 @@ pub enum UdpSocketState {
 /// A UDP socket
 ///
 /// # Fields
-/// - [`UdpSocket::0`]: The socket file descriptor
-/// - [`UdpSocket::1`]: The remote host to connect to
-/// - [`UdpSocket::2`]: The state of the socket
-/// - [`UdpSocket::3`]: The buffer to store data to send
+/// - [`UdpSocket::fd`]: The socket file descriptor
+/// - [`UdpSocket::remote`]: The remote host to connect to
+/// - [`UdpSocket::state`]: The state of the socket
+/// - [`UdpSocket::buffer`]: The buffer to store data to send
 ///
 /// # Notes
 /// - Remote [host](Self::1) is set when the socket is bound calling [`bind()`](UdpSocket::bind)
-pub struct UdpSocket(i32, Option<sockaddr>, UdpSocketState, Box<dyn SocketBuffer>);
+pub struct UdpSocket {
+    fd: i32,
+    remote: Option<sockaddr>,
+    state: UdpSocketState,
+    buffer: Box<dyn SocketBuffer>,
+}
 
 impl UdpSocket {
     #[allow(dead_code)]
     /// Open a socket
     pub fn open() -> Result<UdpSocket, SocketError> {
-        let sock = unsafe { sys::sceNetInetSocket(netc::AF_INET as i32, netc::SOCK_DGRAM, 0) };
-        if sock < 0 {
+        let fd = unsafe { sys::sceNetInetSocket(netc::AF_INET as i32, netc::SOCK_DGRAM, 0) };
+        if fd < 0 {
             Err(SocketError::Errno(unsafe { sys::sceNetInetGetErrno() }))
         } else {
-            Ok(UdpSocket(
-                sock,
-                None,
-                UdpSocketState::Unbound,
-                Box::<Vec<u8>>::default(),
-            ))
+            Ok(UdpSocket {
+                fd,
+                remote: None,
+                state: UdpSocketState::Unbound,
+                buffer: Box::<Vec<u8>>::default(),
+            })
         }
     }
 
@@ -59,7 +64,7 @@ impl UdpSocket {
     /// - `Ok(())` if the binding was successful
     /// - `Err(String)` if the binding was unsuccessful.
     pub fn bind(&mut self, addr: Option<SocketAddr>) -> Result<(), SocketError> {
-        if self.2 != UdpSocketState::Unbound {
+        if self.state != UdpSocketState::Unbound {
             return Err(SocketError::AlreadyBound);
         }
 
@@ -71,7 +76,7 @@ impl UdpSocket {
 
                 if unsafe {
                     sys::sceNetInetBind(
-                        self.0,
+                        self.fd,
                         &sockaddr,
                         core::mem::size_of::<netc::sockaddr>() as u32,
                     )
@@ -80,8 +85,8 @@ impl UdpSocket {
                     let errno = unsafe { sys::sceNetInetGetErrno() };
                     Err(SocketError::Errno(errno))
                 } else {
-                    self.1 = Some(sockaddr);
-                    self.2 = UdpSocketState::Bound;
+                    self.remote = Some(sockaddr);
+                    self.state = UdpSocketState::Bound;
                     Ok(())
                 }
             }
@@ -95,7 +100,7 @@ impl UdpSocket {
     /// # Notes
     /// The socket must be in state [`UdpSocketState::Bound`] to connect to a remote host.
     pub fn connect(&mut self, addr: SocketAddr) -> Result<(), SocketError> {
-        match self.2 {
+        match self.state {
             UdpSocketState::Unbound => return Err(SocketError::NotBound),
             UdpSocketState::Bound => {}
             UdpSocketState::Connected => return Err(SocketError::AlreadyConnected),
@@ -105,12 +110,12 @@ impl UdpSocket {
             SocketAddr::V4(v4) => {
                 let sockaddr = v4.to_sockaddr();
 
-                if unsafe { sys::sceNetInetConnect(self.0, &sockaddr, Self::socket_len()) } != 0 {
+                if unsafe { sys::sceNetInetConnect(self.fd, &sockaddr, Self::socket_len()) } != 0 {
                     let errno = unsafe { sys::sceNetInetGetErrno() };
                     Err(SocketError::Errno(errno))
                 } else {
-                    self.1 = Some(sockaddr);
-                    self.2 = UdpSocketState::Connected;
+                    self.remote = Some(sockaddr);
+                    self.state = UdpSocketState::Connected;
                     Ok(())
                 }
             }
@@ -121,12 +126,12 @@ impl UdpSocket {
     #[allow(unused)]
     /// Read from a socket in state [`UdpSocketState::Connected`]
     fn _read(&mut self, buf: &mut [u8]) -> Result<usize, SocketError> {
-        if self.2 != UdpSocketState::Connected {
+        if self.state != UdpSocketState::Connected {
             return Err(SocketError::NotConnected);
         }
-        let mut sockaddr = self.1.ok_or(SocketError::Other)?;
+        let mut sockaddr = self.remote.ok_or(SocketError::Other)?;
         let result =
-            unsafe { sys::sceNetInetRecv(self.0, buf.as_mut_ptr() as *mut c_void, buf.len(), 0) };
+            unsafe { sys::sceNetInetRecv(self.fd, buf.as_mut_ptr() as *mut c_void, buf.len(), 0) };
         if (result as i32) < 0 {
             Err(SocketError::Errno(unsafe { sys::sceNetInetGetErrno() }))
         } else {
@@ -137,15 +142,15 @@ impl UdpSocket {
     #[allow(unused)]
     /// Write to a socket in state [`UdpSocketState::Bound`]
     fn _read_from(&mut self, buf: &mut [u8]) -> Result<usize, SocketError> {
-        match self.2 {
+        match self.state {
             UdpSocketState::Unbound => return Err(SocketError::NotBound),
             UdpSocketState::Bound => {}
             UdpSocketState::Connected => return Err(SocketError::AlreadyConnected),
         }
-        let mut sockaddr = self.1.ok_or(SocketError::Other)?;
+        let mut sockaddr = self.remote.ok_or(SocketError::Other)?;
         let result = unsafe {
             sys::sceNetInetRecvfrom(
-                self.0,
+                self.fd,
                 buf.as_mut_ptr() as *mut c_void,
                 buf.len(),
                 0,
@@ -163,7 +168,7 @@ impl UdpSocket {
     #[allow(unused)]
     /// Write to a socket in state [`UdpSocketState::Bound`]
     fn _write_to(&mut self, buf: &[u8], len: usize, to: SocketAddr) -> Result<usize, SocketError> {
-        match self.2 {
+        match self.state {
             UdpSocketState::Unbound => return Err(SocketError::NotBound),
             UdpSocketState::Bound => {}
             UdpSocketState::Connected => return Err(SocketError::AlreadyConnected),
@@ -175,11 +180,11 @@ impl UdpSocket {
         }?;
         let socklen = core::mem::size_of::<netc::sockaddr>() as u32;
 
-        self.3.append_buffer(buf);
+        self.buffer.append_buffer(buf);
 
         let result = unsafe {
             sys::sceNetInetSendto(
-                self.0,
+                self.fd,
                 buf.as_ptr() as *const c_void,
                 len,
                 0,
@@ -190,7 +195,7 @@ impl UdpSocket {
         if (result as i32) < 0 {
             Err(SocketError::Errno(unsafe { sys::sceNetInetGetErrno() }))
         } else {
-            self.3.shift_left_buffer(result as usize);
+            self.buffer.shift_left_buffer(result as usize);
             Ok(result as usize)
         }
     }
@@ -198,21 +203,21 @@ impl UdpSocket {
     #[allow(unused)]
     /// Write to a socket in state [`UdpSocketState::Connected`]
     fn _write(&mut self, buf: &[u8]) -> Result<usize, SocketError> {
-        if self.2 != UdpSocketState::Connected {
+        if self.state != UdpSocketState::Connected {
             return Err(SocketError::NotConnected);
         }
 
-        self.3.append_buffer(buf);
+        self.buffer.append_buffer(buf);
 
         self.send()
     }
 
     fn _flush(&mut self) -> Result<(), SocketError> {
-        if self.2 != UdpSocketState::Connected {
+        if self.state != UdpSocketState::Connected {
             return Err(SocketError::NotConnected);
         }
 
-        while !self.3.is_empty() {
+        while !self.buffer.is_empty() {
             self.send()?;
         }
         Ok(())
@@ -221,16 +226,16 @@ impl UdpSocket {
     fn send(&mut self) -> Result<usize, SocketError> {
         let result = unsafe {
             sys::sceNetInetSend(
-                self.0,
-                self.3.as_slice().as_ptr() as *const c_void,
-                self.3.len(),
+                self.fd,
+                self.buffer.as_slice().as_ptr() as *const c_void,
+                self.buffer.len(),
                 0,
             )
         };
         if (result as i32) < 0 {
             Err(SocketError::Errno(unsafe { sys::sceNetInetGetErrno() }))
         } else {
-            self.3.shift_left_buffer(result as usize);
+            self.buffer.shift_left_buffer(result as usize);
             Ok(result as usize)
         }
     }
@@ -238,9 +243,9 @@ impl UdpSocket {
     /// Get the state of the socket
     ///
     /// # Returns
-    /// The state of the socket
-    pub fn get_socket_state(&self) -> UdpSocketState {
-        self.2
+    /// The state of the socket, one of [`UdpSocketState`]
+    pub fn get_state(&self) -> UdpSocketState {
+        self.state
     }
 
     fn socket_len() -> socklen_t {
@@ -252,7 +257,7 @@ impl Drop for UdpSocket {
     /// Close the socket
     fn drop(&mut self) {
         unsafe {
-            sys::sceNetInetClose(self.0);
+            sys::sceNetInetClose(self.fd);
         }
     }
 }
@@ -269,7 +274,7 @@ impl embedded_io::Read for UdpSocket {
     /// otherwise it will attempt to read from the socket. You can check the state of the socket
     /// using [`get_socket_state`](Self::get_socket_state).
     fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
-        match self.get_socket_state() {
+        match self.get_state() {
             UdpSocketState::Unbound => Err(SocketError::NotBound),
             UdpSocketState::Bound => self._read_from(buf),
             UdpSocketState::Connected => self._read(buf),
@@ -284,7 +289,7 @@ impl embedded_io::Write for UdpSocket {
     /// If the socket is not in state [`UdpSocketState::Connected`] this will return an error.
     /// To connect to a remote host use [`connect`](UdpSocket::connect) first.
     fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
-        match self.get_socket_state() {
+        match self.get_state() {
             UdpSocketState::Unbound => Err(SocketError::NotBound),
             UdpSocketState::Bound => Err(SocketError::NotConnected),
             UdpSocketState::Connected => self._write(buf),
@@ -292,7 +297,7 @@ impl embedded_io::Write for UdpSocket {
     }
 
     fn flush(&mut self) -> Result<(), Self::Error> {
-        match self.get_socket_state() {
+        match self.get_state() {
             UdpSocketState::Unbound => Err(SocketError::NotBound),
             UdpSocketState::Bound => Err(SocketError::NotConnected),
             UdpSocketState::Connected => self._flush(),

--- a/src/socket/udp.rs
+++ b/src/socket/udp.rs
@@ -1,4 +1,5 @@
 use alloc::{boxed::Box, vec::Vec};
+use embedded_io::{ErrorType, Read, Write};
 use embedded_nal::{IpAddr, Ipv4Addr, SocketAddr};
 use psp::sys::{self, sockaddr, socklen_t};
 
@@ -28,13 +29,13 @@ pub enum UdpSocketState {
 /// A UDP socket
 ///
 /// # Fields
-/// - [`UdpSocket::fd`]: The socket file descriptor
-/// - [`UdpSocket::remote`]: The remote host to connect to
-/// - [`UdpSocket::state`]: The state of the socket
-/// - [`UdpSocket::buffer`]: The buffer to store data to send
+/// - [`fd`](Self::fd): The socket file descriptor
+/// - [`remote`](Self::remote): The remote host to connect to
+/// - [`state`](Self::state): The state of the socket
+/// - [`buffer`](Self::buffer): The buffer to store data to send
 ///
 /// # Notes
-/// - Remote [host](Self::1) is set when the socket is bound calling [`bind()`](UdpSocket::bind)
+/// - Remote host ([`Self::remote`]) is set when the socket is bound calling [`bind()`](UdpSocket::bind)
 /// - In addition to supporting the creation (with [`new`](Self::new)) and manual management of the socket,
 ///   this struct implements [`EasySocket`] trait, which allows for an easier management of the socket,
 ///   providing the [`open`](Self::open) method as an alternative to [`new`](Self::new).
@@ -277,7 +278,7 @@ impl OptionType for UdpSocket {
     type Options = SocketOptions;
 }
 
-impl embedded_io::ErrorType for UdpSocket {
+impl ErrorType for UdpSocket {
     type Error = SocketError;
 }
 
@@ -290,7 +291,7 @@ impl Open for UdpSocket {
     }
 }
 
-impl embedded_io::Read for UdpSocket {
+impl Read for UdpSocket {
     /// Read from the socket
     ///
     /// # Notes
@@ -306,7 +307,7 @@ impl embedded_io::Read for UdpSocket {
     }
 }
 
-impl embedded_io::Write for UdpSocket {
+impl Write for UdpSocket {
     /// Write to the socket
     ///
     /// # Notes

--- a/src/traits/io.rs
+++ b/src/traits/io.rs
@@ -1,0 +1,25 @@
+use embedded_io::{ErrorType, Read, Write};
+
+pub trait OptionType {
+    type Options: ?Sized;
+}
+
+/// Type implementing this trait support a Open semantics.
+pub trait Open: ErrorType + OptionType {
+    /// Open a resource, using options for configuration.
+    fn open(options: Self::Options) -> Result<Self, Self::Error>
+    where
+        Self: Sized;
+}
+
+/// Types implementing this trait support a simplified socket use.
+///
+/// [`EasySocket`] types support sockets with an Open/Close, Read/Write semantics.
+///
+/// As usual in Rust, no `close` method is needed, as dropping an object should
+/// already close the resources.
+///
+/// # Notes
+/// EasyScoket types should implement in their [`drop`] method the steps required
+/// to close the acquired resources.
+pub trait EasySocket: Open + Write + Read {}

--- a/src/traits/io.rs
+++ b/src/traits/io.rs
@@ -7,7 +7,7 @@ pub trait OptionType {
 /// Type implementing this trait support a Open semantics.
 pub trait Open: ErrorType + OptionType {
     /// Open a resource, using options for configuration.
-    fn open(options: Self::Options) -> Result<Self, Self::Error>
+    fn open(&mut self, options: Self::Options) -> Result<(), Self::Error>
     where
         Self: Sized;
 }

--- a/src/traits/mod.rs
+++ b/src/traits/mod.rs
@@ -1,6 +1,7 @@
 use alloc::vec::Vec;
 
 pub mod dns;
+pub mod io;
 
 /// A trait for a buffer that can be used with a socket
 pub trait SocketBuffer {

--- a/src/traits/mod.rs
+++ b/src/traits/mod.rs
@@ -15,16 +15,20 @@ pub trait SocketBuffer {
     /// Shift the buffer to the left by amount.
     /// This is used to remove data from the buffer.
     fn shift_left_buffer(&mut self, amount: usize);
+
     /// Clear the buffer
     fn clear(&mut self) {
         self.shift_left_buffer(self.len());
     }
+
     /// Check if the buffer is empty
     fn is_empty(&self) -> bool {
         self.len() == 0
     }
+
     /// Get the buffer as a slice
     fn as_slice(&self) -> &[u8];
+
     /// Get the length of the buffer
     fn len(&self) -> usize;
 }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -1,11 +1,16 @@
 use crate::{traits::io::OptionType, SocketAddr};
 
 /// Socket options, such as remote address to connect to.
+///
 /// This is used by [`TcpSocket`](super::socket::tcp::TcpSocket) and
 /// [`UdpSocket`](super::socket::udp::UdpSocket) when used as
 /// [`EasySocket`](super::traits::io::EasySocket)s.
+///
+/// # Fields
+/// - [`remote`]: Remote address to connect to
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct SocketOptions {
+    /// Remote address to connect to
     pub remote: SocketAddr,
 }
 
@@ -25,22 +30,25 @@ impl SocketOptions {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct TlsSocketOptions {
-    pub remote: SocketAddr,
+    // TODO: decomment once found a way to configure server_name in open
+    // pub server_name: String,
     pub seed: u64,
 }
 
 impl TlsSocketOptions {
     /// Create a new socket options
-    pub fn new(remote: SocketAddr, seed: u64) -> Self {
-        Self { remote, seed }
+    pub fn new(/*server_name: String,*/ seed: u64) -> Self {
+        Self {
+            /*server_name,*/ seed,
+        }
     }
 
-    /// Get the remote address
-    pub fn remote(&self) -> SocketAddr {
-        self.remote
-    }
+    // /// Get the remote address
+    // pub fn server_name(&self) -> String {
+    //     self.server_name.clone()
+    // }
 
     /// Get the seed
     pub fn seed(&self) -> u64 {

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -2,7 +2,7 @@ use crate::{traits::io::OptionType, SocketAddr};
 
 #[derive(Clone, Copy)]
 pub struct SocketOptions {
-    remote: SocketAddr,
+    pub remote: SocketAddr,
 }
 
 impl OptionType for SocketOptions {
@@ -21,8 +21,8 @@ impl SocketOptions {
 
 #[derive(Clone, Copy)]
 pub struct TlsSocketOptions {
-    remote: SocketAddr,
-    seed: u64,
+    pub remote: SocketAddr,
+    pub seed: u64,
 }
 
 impl TlsSocketOptions {

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -1,6 +1,10 @@
 use crate::{traits::io::OptionType, SocketAddr};
 
-#[derive(Clone, Copy)]
+/// Socket options, such as remote address to connect to.
+/// This is used by [`TcpSocket`](super::socket::tcp::TcpSocket) and
+/// [`UdpSocket`](super::socket::udp::UdpSocket) when used as
+/// [`EasySocket`](super::traits::io::EasySocket)s.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct SocketOptions {
     pub remote: SocketAddr,
 }
@@ -10,30 +14,35 @@ impl OptionType for SocketOptions {
 }
 
 impl SocketOptions {
+    /// Create a new socket options
     pub fn new(remote: SocketAddr) -> SocketOptions {
         Self { remote }
     }
 
+    /// Get the remote address
     pub fn remote(&self) -> SocketAddr {
         self.remote
     }
 }
 
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct TlsSocketOptions {
     pub remote: SocketAddr,
     pub seed: u64,
 }
 
 impl TlsSocketOptions {
+    /// Create a new socket options
     pub fn new(remote: SocketAddr, seed: u64) -> Self {
         Self { remote, seed }
     }
 
+    /// Get the remote address
     pub fn remote(&self) -> SocketAddr {
         self.remote
     }
 
+    /// Get the seed
     pub fn seed(&self) -> u64 {
         self.seed
     }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -1,0 +1,40 @@
+use crate::{traits::io::OptionType, SocketAddr};
+
+#[derive(Clone, Copy)]
+pub struct SocketOptions {
+    remote: SocketAddr,
+}
+
+impl OptionType for SocketOptions {
+    type Options = Self;
+}
+
+impl SocketOptions {
+    pub fn new(remote: SocketAddr) -> SocketOptions {
+        Self { remote }
+    }
+
+    pub fn remote(&self) -> SocketAddr {
+        self.remote
+    }
+}
+
+#[derive(Clone, Copy)]
+pub struct TlsSocketOptions {
+    remote: SocketAddr,
+    seed: u64,
+}
+
+impl TlsSocketOptions {
+    pub fn new(remote: SocketAddr, seed: u64) -> Self {
+        Self { remote, seed }
+    }
+
+    pub fn remote(&self) -> SocketAddr {
+        self.remote
+    }
+
+    pub fn seed(&self) -> u64 {
+        self.seed
+    }
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,9 +1,9 @@
-#[allow(dead_code)]
-#[inline]
 /// Load net modules
 ///
 /// # Safety
 /// This function is unsafe because it loads `rust-psp`'s net modules, which are unsafe.
+#[allow(dead_code)]
+#[inline]
 pub unsafe fn load_net_modules() {
     psp::sys::sceUtilityLoadNetModule(psp::sys::NetModule::NetCommon);
     psp::sys::sceUtilityLoadNetModule(psp::sys::NetModule::NetInet);
@@ -11,12 +11,12 @@ pub unsafe fn load_net_modules() {
     psp::sys::sceUtilityLoadNetModule(psp::sys::NetModule::NetHttp);
 }
 
-#[allow(dead_code)]
-#[inline]
 /// Initialize net modules
 ///
 /// # Safety
 /// This function is unsafe because it loads `rust-psp`'s net modules, which are unsafe.
+#[allow(dead_code)]
+#[inline]
 pub unsafe fn net_init() {
     psp::sys::sceNetInit(0x20000, 0x20, 0x1000, 0x20, 0x1000);
     psp::sys::sceNetInetInit();


### PR DESCRIPTION
Refactor sockets and traits implementations and creates a new trait, named `EasySocket` which encapsulates the concept of having a socket with an Open/Close semantics (Close is implemented in `Drop`, with all the known limitations).

Full changelog:
- Create `EasySocket` trait, as composition of `Open`, `Read`, and `Write` traits (and other for error handling and configurable options)
- Refactor crate's sockets to implement `EasySocket`
- Improve docs and style.