### PR TITLE
fix: publish when a new tag is created

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,10 +1,7 @@
 name: Publish
 
 on:
-  # only when Cargo.toml is changed and a new tag is created
   push:
-    paths:
-      - Cargo.toml
     tags:
       - "v*"
 


### PR DESCRIPTION
Current Publish Action `on` has a useless `path: Cargo.toml`. It should only have `tags: ["v*"]`