### PR TITLE
feat: improve TLS socket

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -509,7 +509,7 @@ dependencies = [
 
 [[package]]
 name = "psp-net"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "dns-protocol",
  "embedded-io",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "psp-net"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 license-file = "LICENSE"
 keywords = ["psp", "net", "networking", "embedded", "gamedev"]

--- a/src/socket/tcp.rs
+++ b/src/socket/tcp.rs
@@ -204,18 +204,18 @@ impl ErrorType for TcpSocket {
 }
 
 impl OptionType for TcpSocket {
-    type Options = SocketOptions;
+    type Options<'a> = SocketOptions;
 }
 
-impl Open for TcpSocket {
+impl<'a> Open<'a> for TcpSocket {
     /// Return a TCP socket connected to the remote specified in `options`
-    fn open(&mut self, options: Self::Options) -> Result<(), Self::Error>
+    fn open(mut self, options: &'a Self::Options<'a>) -> Result<Self, Self::Error>
     where
         Self: Sized,
     {
         self.connect(options.remote())?;
 
-        Ok(())
+        Ok(self)
     }
 }
 

--- a/src/socket/tls.rs
+++ b/src/socket/tls.rs
@@ -35,8 +35,6 @@ impl<'a> TlsSocket<'a> {
     /// - `socket`: The TCP socket to use for the TLS connection
     /// - `record_read_buf`: A buffer to use for reading records
     /// - `record_write_buf`: A buffer to use for writing records
-    /// - `server_name`: The server name to connect to (e.g. "example.com")
-    /// - `cert`: An optional certificate to use for the connection
     ///
     /// # Returns
     /// A new TLS socket.
@@ -126,13 +124,21 @@ where
 
         self.tls_config = self.tls_config.with_server_name(options.server_name());
 
-        if options.enable_rsa_signatures {
+        if options.rsa_signatures_enabled() {
             self.tls_config = self.tls_config.enable_rsa_signatures();
         }
 
-        if let Some(cert) = &options.cert {
+        if options.reset_max_fragment_length() {
+            self.tls_config = self.tls_config.reset_max_fragment_length();
+        }
+
+        if let Some(cert) = options.cert() {
             // self.certificate = Some(Certificate::RawPublicKey(cert));
             self.tls_config = self.tls_config.with_cert(cert.clone());
+        }
+
+        if let Some(ca) = options.ca() {
+            self.tls_config = self.tls_config.with_ca(ca.clone());
         }
 
         let tls_context = TlsContext::new(&self.tls_config, &mut rng);

--- a/src/socket/tls.rs
+++ b/src/socket/tls.rs
@@ -1,8 +1,6 @@
 use alloc::string::String;
 use embedded_io::{ErrorType, Read, Write};
-use embedded_tls::{
-    blocking::TlsConnection, Aes128GcmSha256, Certificate, NoVerify, TlsConfig, TlsContext,
-};
+use embedded_tls::{blocking::TlsConnection, Aes128GcmSha256, NoVerify, TlsConfig, TlsContext};
 
 use rand::SeedableRng;
 use rand_chacha::ChaCha20Rng;
@@ -50,7 +48,7 @@ impl<'a> TlsSocket<'a> {
     /// ```no_run
     /// let mut read_buf = TlsSocket::new_buffer();
     /// let mut write_buf = TlsSocket::new_buffer();
-    /// let tls_socket = TlsSocket::new(tcp_socket, &mut read_buf, &mut write_buf, "example.com", None);
+    /// let tls_socket = TlsSocket::new(tcp_socket, &mut read_buf, &mut write_buf);
     /// ```
     ///
     /// # Notes
@@ -81,7 +79,7 @@ impl<'a> TlsSocket<'a> {
     /// ```no_run
     /// let mut read_buf = TlsSocket::new_buffer();
     /// let mut write_buf = TlsSocket::new_buffer();
-    /// let tls_socket = TlsSocket::new(tcp_socket, &mut read_buf, &mut write_buf, "example.com", None);
+    /// let tls_socket = TlsSocket::new(tcp_socket, &mut read_buf, &mut write_buf);
     /// ```
     #[must_use]
     pub fn new_buffer() -> [u8; 16_384] {
@@ -115,7 +113,7 @@ impl ErrorType for TlsSocket<'_> {
 }
 
 impl OptionType for TlsSocket<'_> {
-    type Options<'a> = TlsSocketOptions;
+    type Options<'a> = TlsSocketOptions<'a>;
 }
 
 impl<'a, 'b> Open<'a> for TlsSocket<'b>
@@ -134,7 +132,7 @@ where
 
         if let Some(cert) = &options.cert {
             // self.certificate = Some(Certificate::RawPublicKey(cert));
-            self.tls_config = self.tls_config.with_cert(Certificate::RawPublicKey(cert));
+            self.tls_config = self.tls_config.with_cert(cert.clone());
         }
 
         let tls_context = TlsContext::new(&self.tls_config, &mut rng);

--- a/src/socket/udp.rs
+++ b/src/socket/udp.rs
@@ -360,20 +360,20 @@ impl Drop for UdpSocket {
 }
 
 impl OptionType for UdpSocket {
-    type Options = SocketOptions;
+    type Options<'a> = SocketOptions;
 }
 
 impl ErrorType for UdpSocket {
     type Error = SocketError;
 }
 
-impl Open for UdpSocket {
+impl<'a> Open<'a> for UdpSocket {
     /// Open the socket
-    fn open(&mut self, options: Self::Options) -> Result<(), Self::Error> {
+    fn open(mut self, options: &'a Self::Options<'a>) -> Result<Self, Self::Error> {
         self.bind(None)?;
         self.connect(options.remote())?;
 
-        Ok(())
+        Ok(self)
     }
 }
 

--- a/src/traits/io.rs
+++ b/src/traits/io.rs
@@ -1,14 +1,14 @@
 pub trait OptionType {
-    type Options: ?Sized;
+    type Options<'b>: ?Sized;
 }
 
 /// Type implementing this trait support a Open semantics.
-pub trait Open: ErrorType + OptionType {
+pub trait Open<'a>: ErrorType + OptionType {
     /// Open a resource, using options for configuration.
     ///
     /// # Errors
     /// This function can return an error if the resource could not be opened.
-    fn open(&mut self, options: Self::Options) -> Result<(), Self::Error>
+    fn open(self, options: &'a Self::Options<'a>) -> Result<Self, Self::Error>
     where
         Self: Sized;
 }
@@ -27,7 +27,7 @@ pub trait Open: ErrorType + OptionType {
 /// # Notes
 /// [`EasySocket`] types should implement in their [`drop`] method the steps required
 /// to close the acquired resources.
-pub trait EasySocket: Open + Write + Read {}
+pub trait EasySocket: for<'a> Open<'a> + Write + Read {}
 
 // re-exports
 pub trait Write = embedded_io::Write;

--- a/src/traits/io.rs
+++ b/src/traits/io.rs
@@ -6,8 +6,15 @@ pub trait OptionType {
 pub trait Open<'a>: ErrorType + OptionType {
     /// Open a resource, using options for configuration.
     ///
+    /// # Arguments
+    /// - `options`: The options to use to configure the TLS connection
+    ///
     /// # Errors
     /// This function can return an error if the resource could not be opened.
+    ///
+    /// # Notes
+    /// See [`TlsSocketOptions`](crate::types::TlsSocketOptions) for more information
+    /// on the options you can pass.
     fn open(self, options: &'a Self::Options<'a>) -> Result<Self, Self::Error>
     where
         Self: Sized;

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -1,3 +1,5 @@
+use alloc::{string::String, vec::Vec};
+
 use crate::socket::SocketAddr;
 
 /// Socket options, such as remote address to connect to.
@@ -35,13 +37,28 @@ impl SocketOptions {
 /// - [`seed`](Self::seed): Seed for the RNG
 pub struct TlsSocketOptions {
     pub seed: u64,
+    pub server_name: String,
+    pub(crate) cert: Option<Vec<u8>>,
+    pub(crate) enable_rsa_signatures: bool,
 }
 
-impl TlsSocketOptions {
+impl<'a> TlsSocketOptions {
     /// Create a new socket options
     #[must_use]
-    pub fn new(seed: u64) -> Self {
-        Self { seed }
+    pub fn new(seed: u64, server_name: String, cert: Option<Vec<u8>>) -> Self {
+        Self {
+            seed,
+            server_name,
+            cert,
+            enable_rsa_signatures: true,
+        }
+    }
+
+    /// Disable RSA signatures
+    ///
+    /// By default, RSA signatures are enabled.
+    pub fn disable_rsa_signatures(&mut self) {
+        self.enable_rsa_signatures = false;
     }
 
     /// Get the seed
@@ -49,4 +66,11 @@ impl TlsSocketOptions {
     pub fn seed(&self) -> u64 {
         self.seed
     }
+
+    pub fn server_name(&self) -> &str {
+        &self.server_name
+    }
 }
+
+// re-exports
+pub type Certificate<'a> = embedded_tls::Certificate<'a>;

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -30,8 +30,11 @@ impl SocketOptions {
     }
 }
 
+/// TLS socket options.
+///
+/// This is used by [`TlsSocket`](super::socket::tls::TlsSocket) when used as a
+/// [`EasySocket`](super::traits::io::EasySocket).
 #[derive(Clone, Debug)]
-/// TLS socket options
 pub struct TlsSocketOptions<'a> {
     seed: u64,
     server_name: String,

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -1,4 +1,4 @@
-use alloc::{string::String, vec::Vec};
+use alloc::string::String;
 
 use crate::socket::SocketAddr;
 
@@ -30,26 +30,26 @@ impl SocketOptions {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug)]
 /// TLS socket options
 ///
 /// # Fields
 /// - [`seed`](Self::seed): Seed for the RNG
-pub struct TlsSocketOptions {
+pub struct TlsSocketOptions<'a> {
     pub seed: u64,
     pub server_name: String,
-    pub(crate) cert: Option<Vec<u8>>,
+    pub(crate) cert: Option<Certificate<'a>>,
     pub(crate) enable_rsa_signatures: bool,
 }
 
-impl<'a> TlsSocketOptions {
+impl<'a> TlsSocketOptions<'a> {
     /// Create a new socket options
     #[must_use]
-    pub fn new(seed: u64, server_name: String, cert: Option<Vec<u8>>) -> Self {
+    pub fn new(seed: u64, server_name: String) -> Self {
         Self {
             seed,
             server_name,
-            cert,
+            cert: None,
             enable_rsa_signatures: true,
         }
     }
@@ -61,12 +61,22 @@ impl<'a> TlsSocketOptions {
         self.enable_rsa_signatures = false;
     }
 
+    /// Set the certificate
+    ///
+    /// # Arguments
+    /// - `cert`: The certificate
+    pub fn set_cert(&mut self, cert: Certificate<'a>) {
+        self.cert = Some(cert);
+    }
+
     /// Get the seed
     #[must_use]
     pub fn seed(&self) -> u64 {
         self.seed
     }
 
+    /// Get the server name
+    #[must_use]
     pub fn server_name(&self) -> &str {
         &self.server_name
     }

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -32,25 +32,30 @@ impl SocketOptions {
 
 #[derive(Clone, Debug)]
 /// TLS socket options
-///
-/// # Fields
-/// - [`seed`](Self::seed): Seed for the RNG
 pub struct TlsSocketOptions<'a> {
-    pub seed: u64,
-    pub server_name: String,
-    pub(crate) cert: Option<Certificate<'a>>,
-    pub(crate) enable_rsa_signatures: bool,
+    seed: u64,
+    server_name: String,
+    cert: Option<Certificate<'a>>,
+    ca: Option<Certificate<'a>>,
+    enable_rsa_signatures: bool,
+    reset_max_fragment_length: bool,
 }
 
 impl<'a> TlsSocketOptions<'a> {
     /// Create a new socket options
+    ///
+    /// # Arguments
+    /// - `seed`: The seed to use for the RNG
+    /// - `server_name`: The server name to use
     #[must_use]
     pub fn new(seed: u64, server_name: String) -> Self {
         Self {
             seed,
             server_name,
             cert: None,
+            ca: None,
             enable_rsa_signatures: true,
+            reset_max_fragment_length: false,
         }
     }
 
@@ -79,6 +84,45 @@ impl<'a> TlsSocketOptions<'a> {
     #[must_use]
     pub fn server_name(&self) -> &str {
         &self.server_name
+    }
+
+    /// Get the certificate
+    #[must_use]
+    pub fn cert(&self) -> Option<&Certificate<'a>> {
+        self.cert.as_ref()
+    }
+
+    /// Return whether RSA signatures are enabled
+    #[must_use]
+    pub fn rsa_signatures_enabled(&self) -> bool {
+        self.enable_rsa_signatures
+    }
+
+    /// Return whether the max fragment length should be reset
+    #[must_use]
+    pub fn reset_max_fragment_length(&self) -> bool {
+        self.reset_max_fragment_length
+    }
+
+    /// Set whether the max fragment length should be reset
+    ///
+    /// By default, the max fragment length is not reset.
+    pub fn set_reset_max_fragment_length(&mut self, reset_max_fragment_length: bool) {
+        self.reset_max_fragment_length = reset_max_fragment_length;
+    }
+
+    /// Get the CA
+    #[must_use]
+    pub fn ca(&self) -> Option<&Certificate<'a>> {
+        self.ca.as_ref()
+    }
+
+    /// Set the CA (certificate authority)
+    ///
+    /// # Arguments
+    /// - `ca`: The CA
+    pub fn set_ca(&mut self, ca: Option<Certificate<'a>>) {
+        self.ca = ca;
     }
 }
 

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -13,7 +13,7 @@ use crate::socket::SocketAddr;
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct SocketOptions {
     /// Remote address to connect to
-    pub remote: SocketAddr,
+    remote: SocketAddr,
 }
 
 impl SocketOptions {


### PR DESCRIPTION
Improve `TlsSocket` so that most TLS options (such as cert, CA, server name, etc.) can be set through `open`, and not during `new`.

This removes the "splitting" between TLS options, that previously required some to be set through `new` and other through `open`.

In order to do so, and be compatible with embedded_tls, the Open and Option traits need to be revisited and some playing with lifetimes is required. This is a "necessary evil' to improve the TLS socket overall semantics.