### PR TITLE
ci: set rust nightly version

### DIFF
--- a/.github/workflows/check-and-lint.yaml
+++ b/.github/workflows/check-and-lint.yaml
@@ -10,6 +10,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  TOOLCHAIN_VERSION: nightly-2024-06-01
 
 jobs:
   fmt:
@@ -21,7 +22,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
+          toolchain: "$env.TOOLCHAIN_VERSION"
           override: true
 
       - run: rustup component add rustfmt
@@ -39,7 +40,7 @@ jobs:
 
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
+          toolchain: "$env.TOOLCHAIN_VERSION"
           components: clippy
           override: true
 

--- a/.github/workflows/check-and-lint.yaml
+++ b/.github/workflows/check-and-lint.yaml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: "$env.TOOLCHAIN_VERSION"
+          toolchain: ${{ env.TOOLCHAIN_VERSION }}
           override: true
 
       - run: rustup component add rustfmt
@@ -40,7 +40,7 @@ jobs:
 
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: "$env.TOOLCHAIN_VERSION"
+          toolchain: ${{ env.TOOLCHAIN_VERSION }}
           components: clippy
           override: true
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -11,6 +11,7 @@ jobs:
 
     env:
       CARGO_TERM_COLOR: always
+      TOOLCHAIN_VERSION: nightly-2024-06-01
 
     steps:
       - uses: actions/checkout@v4
@@ -18,7 +19,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
+          toolchain: ${{ env.TOOLCHAIN_VERSION }}
           override: true
 
       # if build fails, we don't publish

--- a/.github/workflows/push-to-master.yaml
+++ b/.github/workflows/push-to-master.yaml
@@ -11,6 +11,7 @@ jobs:
 
     env:
       CARGO_TERM_COLOR: always
+      TOOLCHAIN_VERSION: nightly-2024-06-01
 
     steps:
       - uses: actions/checkout@v4
@@ -18,7 +19,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly
+          toolchain: ${{ env.TOOLCHAIN_VERSION }}
           override: true
 
       - name: Build


### PR DESCRIPTION
Pin rust toolchain version though a variable in pipelines.

### Motivation
The motivation for this is that this crate is not guaranteed to build with the latest toolchain version (e.g. if the `rust-psp` dependency's panic implementation breaks). When the latest version of Rust is incompatible with this crate or its dependencies, all pipelines fail.

Pros:
- since it is not guarantee for the crate to compile with latest, this makes the pipelines' behaviour consistent with that
- is easier to debug/reproduce pipelines fails.
Cons:
- will have to keep the version up-to-date.

### Subsequent Work
It is needed to document the MSRV, and the latest version the crate's been tested on.