### PR TITLE
feat: use `thiserror` crate and add an ad-hoc tls socket error

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,6 +72,12 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
@@ -160,6 +166,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "defmt"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a99dd22262668b887121d4672af5a64b238f026099f1a2a1b322066c9ecfe9e0"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9f309eff1f79b3ebdf252954d90ae440599c26c2c553fe87a2d17195f2dcb"
+dependencies = [
+ "defmt-parser",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff4a5fefe330e8d7f31b16a318f9ce81000d8e35e69b93eae154d16d2278f70f"
+dependencies = [
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "der"
 version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -213,6 +251,9 @@ name = "embedded-io"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
+dependencies = [
+ "defmt",
+]
 
 [[package]]
 name = "embedded-io-async"
@@ -231,6 +272,7 @@ checksum = "a6efb76fdd004a4ef787640177237b83449e6c5847765ea50bf15900061fd601"
 dependencies = [
  "aes-gcm",
  "atomic-polyfill",
+ "defmt",
  "digest",
  "embedded-io",
  "embedded-io-async",
@@ -341,6 +383,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
 dependencies = [
+ "defmt",
  "hash32 0.3.1",
  "stable_deref_trait",
 ]
@@ -422,7 +465,7 @@ checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -475,10 +518,34 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro2"
-version = "1.0.79"
+name = "proc-macro-error"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.93"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
 dependencies = [
  "unicode-ident",
 ]
@@ -489,7 +556,7 @@ version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad5aaa74ac3077dfbbb2d13f19cc4f9d32534f4c620dedaa2fb2f706191d3b46"
 dependencies = [
- "bitflags",
+ "bitflags 2.8.0",
  "libm",
  "num_enum",
  "num_enum_derive",
@@ -502,7 +569,7 @@ name = "psp-net"
 version = "0.6.4"
 dependencies = [
  "base64",
- "bitflags",
+ "bitflags 2.8.0",
  "dns-protocol",
  "embedded-io",
  "embedded-tls",
@@ -512,6 +579,7 @@ dependencies = [
  "rand",
  "rand_chacha",
  "regex",
+ "thiserror 2.0.11",
 ]
 
 [[package]]
@@ -617,13 +685,63 @@ checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
 
 [[package]]
 name = "syn"
-version = "2.0.58"
+version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44cfb93f38070beee36b3fef7d4f5a16f27751d94b187b666a5cc5e9b0d30687"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.98"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36147f1a48ae0ec2b5b3bc5b537d267457555a10dc06f3dbc8cb11ba3006d3b1"
 dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
+dependencies = [
+ "thiserror-impl 2.0.11",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -566,7 +566,7 @@ dependencies = [
 
 [[package]]
 name = "psp-net"
-version = "0.6.4"
+version = "0.6.5"
 dependencies = [
  "base64",
  "bitflags 2.8.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "psp-net"
-version = "0.6.4"
+version = "0.6.5"
 edition = "2021"
 license-file = "LICENSE"
 keywords = ["psp", "net", "networking", "embedded", "gamedev"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ psp = ["dep:psp"]
 [dependencies]
 psp = { version = "0.3.11", optional = true}
 dns-protocol = { version = "0.1.1", default-features = false }
-embedded-tls = { version = "0.17.0", default-features = false }
+embedded-tls = { version = "0.17.0", default-features = false, features = ["defmt"]}
 embedded-io = { version = "0.6.1", default-features = false }
 rand = { version = "0.8.5", default-features = false }
 rand_chacha = { version = "0.3.1", default-features = false }
@@ -30,3 +30,4 @@ lazy_static = { version = "1.5.0", default-features = false, features = [
 bitflags = { version = "2.8.0", default-features = false }
 httparse = { version = "1.10.0", default-features = false, optional = true }
 base64 = {version = "0.22", default-features = false, features = ["alloc"] }
+thiserror = { version = "2.0.11", default-features = false }

--- a/src/socket/error.rs
+++ b/src/socket/error.rs
@@ -48,14 +48,16 @@ impl embedded_io::Error for SocketError {
 /// underlying socket.
 #[derive(Debug, Clone, Error)]
 pub enum TlsSocketError {
+    /// TLS error
     #[error("TLS error: {}", 0)]
     TlsError(TlsError),
+    /// An error with the under
     #[error("Socket error: {0}")]
     SocketError(#[from] SocketError),
 }
 
 impl TlsSocketError {
-    /// Returns `true` if the tls socket error is [`TlsError`].
+    /// Returns `true` if the error is a [`TlsError`].
     ///
     /// [`TlsError`]: TlsSocketError::TlsError
     #[must_use]
@@ -63,7 +65,7 @@ impl TlsSocketError {
         matches!(self, Self::TlsError(..))
     }
 
-    /// Returns `true` if the tls socket error is [`SocketError`].
+    /// Returns `true` if the error is a [`SocketError`].
     ///
     /// [`SocketError`]: TlsSocketError::SocketError
     #[must_use]

--- a/src/socket/error.rs
+++ b/src/socket/error.rs
@@ -1,5 +1,4 @@
 use alloc::string::String;
-use embedded_tls::TlsError;
 use thiserror::Error;
 
 /// An error that can occur with a socket
@@ -87,3 +86,6 @@ impl embedded_io::Error for TlsSocketError {
         }
     }
 }
+
+// re-exports
+pub type TlsError = embedded_tls::TlsError;

--- a/src/socket/tls.rs
+++ b/src/socket/tls.rs
@@ -16,7 +16,6 @@ use crate::{
 };
 
 use super::{
-    error::TlsSocketError,
     state::{Connected, NotReady, Ready, SocketState},
     tcp::TcpSocket,
 };
@@ -118,9 +117,9 @@ impl TlsSocket<'_, Ready> {
     /// - `Err(TlsError)` if the write was unsuccessful.
     ///
     /// # Errors
-    /// [`TlsSocketError`] if the write fails.
-    pub fn write_all(&mut self, buf: &[u8]) -> Result<(), TlsSocketError> {
-        self.tls_connection.write_all(buf).map_err(Into::into)
+    /// [`embedded_tls::TlsError`] if the write fails.
+    pub fn write_all(&mut self, buf: &[u8]) -> Result<(), embedded_tls::TlsError> {
+        self.tls_connection.write_all(buf)
     }
 
     /// Read data from the TLS connection and converts it to a [`String`].
@@ -130,8 +129,8 @@ impl TlsSocket<'_, Ready> {
     /// - `Err(TlsError)` if the read was unsuccessful.
     ///
     /// # Errors
-    /// [`TlsSocketError`] if the read fails.
-    pub fn read_string(&mut self) -> Result<String, TlsSocketError> {
+    /// [`embedded_tls::TlsError`] if the read fails.
+    pub fn read_string(&mut self) -> Result<String, embedded_tls::TlsError> {
         let mut buf = TlsSocket::new_buffer();
         let _ = self.read(&mut buf)?;
 
@@ -143,7 +142,7 @@ impl TlsSocket<'_, Ready> {
 
 impl<S: SocketState> ErrorType for TlsSocket<'_, S> {
     /// The error type for the TLS socket.
-    type Error = TlsSocketError;
+    type Error = embedded_tls::TlsError;
 }
 
 impl<S: SocketState> OptionType for TlsSocket<'_, S> {
@@ -173,7 +172,7 @@ where
     /// # Notes
     /// The function takes ownership of the socket ([`TcpSocket<NotReady>`]), and returns a new socket of type [`TlsSocket<Ready>`].
     /// Therefore, you must assign the returned socket to a variable in order to use it.
-    fn open(self, options: &'b Self::Options<'_>) -> Result<Self::Return, TlsSocketError>
+    fn open(self, options: &'b Self::Options<'_>) -> Result<Self::Return, embedded_tls::TlsError>
     where
         'b: 'a,
     {
@@ -224,7 +223,7 @@ impl embedded_io::Read for TlsSocket<'_, Ready> {
     /// - `Ok(usize)` if the read was successful. The number of bytes read
     /// - `Err(SocketError)` if the read was unsuccessful.
     fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
-        self.tls_connection.read(buf).map_err(Into::into)
+        self.tls_connection.read(buf)
     }
 }
 
@@ -238,12 +237,12 @@ impl embedded_io::Write for TlsSocket<'_, Ready> {
     /// - `Ok(usize)` if the write was successful. The number of bytes written
     /// - `Err(SocketError)` if the write was unsuccessful.
     fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
-        self.tls_connection.write(buf).map_err(Into::into)
+        self.tls_connection.write(buf)
     }
 
     /// Flush the TLS connection.
     fn flush(&mut self) -> Result<(), Self::Error> {
-        self.tls_connection.flush().map_err(Into::into)
+        self.tls_connection.flush()
     }
 }
 


### PR DESCRIPTION
- Use `thiserror` crate
- Add `TlsSocketError` that encapsulate either TLS errors or errors coming from the underlying socket.